### PR TITLE
[BREAKING] Convert native class Table to extend from EmberObject

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ export default Ember.Component.extend({
     // Data can be from any source
     let rows = this.get('model');
 
-    return new Table([
+    return Table.create([
       {
         label: 'Name',
         valuePath: 'name'

--- a/addon/classes/table.js
+++ b/addon/classes/table.js
@@ -90,11 +90,15 @@ const Table = EmberObject.extend({
 
 Table.reopenClass({
   /**
-   * @class Table
-   * @constructor
-   * @param  {Array} columns
-   * @param  {Array} rows
+   * Create a new Table object.
+   *
+   * @method create
+   * @param  {Array}  [columns]
+   * @param  {Array}  [rows]
+   * @param  {Object} [options]
+   * @return {Table}
    * @public
+   * @static
    */
   create(columns = [], rows = [], options = {}) {
     return this._super(assign({}, options, {

--- a/addon/classes/table.js
+++ b/addon/classes/table.js
@@ -1,5 +1,6 @@
 import { empty, filterBy } from '@ember/object/computed';
 import { A as emberArray } from '@ember/array';
+import { assign }  from '@ember/polyfills';
 import EmberObject from '@ember/object';
 import Row from 'ember-semantic-ui-table/classes/row';
 import Column from 'ember-semantic-ui-table/classes/column';
@@ -9,7 +10,7 @@ import Column from 'ember-semantic-ui-table/classes/column';
  * @extends Ember.Object
  * @namespace SemanticUI
  */
-export default class Table extends EmberObject.extend({
+const Table = EmberObject.extend({
   /**
    * @property columns
    * @type Ember.Array
@@ -66,26 +67,7 @@ export default class Table extends EmberObject.extend({
    * @type Ember.Array
    * @public
    */
-  sortedColumns: filterBy('columns', 'sorted', true).readOnly()
-}) {
-  /**
-   * @class Table
-   * @constructor
-   * @param  {Array} columns
-   * @param  {Array} rows
-   * @public
-   */
-  constructor(columns = [], rows = []) {
-    super();
-
-    let _columns = emberArray(Table.createColumns(columns));
-    let _rows = emberArray(Table.createRows(rows));
-
-    this.setProperties({
-      columns: _columns,
-      rows: _rows
-    });
-  }
+  sortedColumns: filterBy('columns', 'sorted', true).readOnly(),
 
   /**
    * @method setColumns
@@ -94,7 +76,7 @@ export default class Table extends EmberObject.extend({
    */
   setColumns(columns) {
     this.set('columns', Table.createColumns(columns));
-  }
+  },
 
   /**
    * @method setRows
@@ -103,7 +85,23 @@ export default class Table extends EmberObject.extend({
    */
   setRows(rows) {
     this.set('rows', Table.createRows(rows));
-  }
+  },
+});
+
+Table.reopenClass({
+  /**
+   * @class Table
+   * @constructor
+   * @param  {Array} columns
+   * @param  {Array} rows
+   * @public
+   */
+  create(columns = [], rows = [], options = {}) {
+    return this._super(assign({}, options, {
+      columns: emberArray(Table.createColumns(columns)),
+      rows: emberArray(Table.createRows(rows)),
+    }));
+  },
 
   /**
    * Create a collection of Row objects with the given collection
@@ -113,7 +111,7 @@ export default class Table extends EmberObject.extend({
    * @public
    * @static
    */
-  static createRows(rows = [], options = {}) {
+  createRows(rows = [], options = {}) {
     return rows.map((r) => {
       if (r instanceof Row) {
         return r;
@@ -121,7 +119,7 @@ export default class Table extends EmberObject.extend({
         return Row.create(r, options);
       }
     });
-  }
+  },
 
   /**
    * Create a collection of Column objects with the given collection
@@ -131,7 +129,7 @@ export default class Table extends EmberObject.extend({
    * @public
    * @static
    */
-  static createColumns(columns = []) {
+  createColumns(columns = []) {
     return columns.map((c) => {
       if (c instanceof Column) {
         return c;
@@ -139,5 +137,7 @@ export default class Table extends EmberObject.extend({
         return Column.create(c);
       }
     });
-  }
-}
+  },
+});
+
+export default Table;

--- a/tests/dummy/app/components/basic-table.js
+++ b/tests/dummy/app/components/basic-table.js
@@ -23,7 +23,7 @@ export default Component.extend(Columns, {
   }),
 
   table: computed('columns', 'rows', function() {
-    return new Table(this.get('columns'), this.get('rows'));
+    return Table.create(this.get('columns'), this.get('rows'));
   })
 });
 // END-SNIPPET components-basic-table

--- a/tests/dummy/app/components/custom-types.js
+++ b/tests/dummy/app/components/custom-types.js
@@ -35,7 +35,7 @@ export default Component.extend(Columns, {
   }),
 
   table: computed('columns', 'rows', function() {
-    return new Table(this.get('columns'), this.get('model'));
+    return Table.create(this.get('columns'), this.get('model'));
   })
 });
 // END-SNIPPET components-custom-types

--- a/tests/dummy/app/components/editable-example.js
+++ b/tests/dummy/app/components/editable-example.js
@@ -52,7 +52,7 @@ export default Component.extend(Columns, {
   }),
 
   table: computed('columns', 'model', function() {
-    return new Table(this.get('columns'), this.get('model'));
+    return Table.create(this.get('columns'), this.get('model'));
   }),
 
   actions: {

--- a/tests/dummy/app/components/ember-data.js
+++ b/tests/dummy/app/components/ember-data.js
@@ -10,7 +10,7 @@ export default Component.extend(Columns, {
   layout,
 
   table: computed('columns', 'model', function() {
-    return new Table(this.get('columns'), this.get('model'));
+    return Table.create(this.get('columns'), this.get('model'));
   })
 });
 // END-SNIPPET components-ember-data

--- a/tests/dummy/app/components/expanded-row-example.js
+++ b/tests/dummy/app/components/expanded-row-example.js
@@ -34,7 +34,7 @@ export default Component.extend(Columns, {
   }),
 
   table: computed('columns', 'rows', function() {
-    return new Table(this.get('columns'), this.get('model'));
+    return Table.create(this.get('columns'), this.get('model'));
   })
 });
 // END-SNIPPET components-expanded-row-example

--- a/tests/dummy/app/components/interactive-ember-data.js
+++ b/tests/dummy/app/components/interactive-ember-data.js
@@ -19,7 +19,7 @@ export default Component.extend(Columns, EmberDataTable, {
     let columns = this.get('columns');
     columns[0].sortable = true;
     columns[1].sortable = true;
-    return new Table(columns, []);
+    return Table.create(columns, []);
   }),
 
   actions: {

--- a/tests/dummy/app/components/translatable-header.js
+++ b/tests/dummy/app/components/translatable-header.js
@@ -38,7 +38,7 @@ export default Component.extend(Columns, {
   }),
 
   table: computed('columns', 'rows', function() {
-    return new Table(this.get('columns'), this.get('model'));
+    return Table.create(this.get('columns'), this.get('model'));
   })
 });
 // END-SNIPPET components-translatable-header

--- a/tests/dummy/app/mixins/ember-data-table.js
+++ b/tests/dummy/app/mixins/ember-data-table.js
@@ -41,7 +41,7 @@ export default Mixin.create({
   isLoading: false,
 
   table: computed(function() {
-    return new Table(this.get('columns'), []);
+    return Table.create(this.get('columns'), []);
   }),
 
   fetchRecords() {

--- a/tests/integration/components/table-cell/row-index-test.js
+++ b/tests/integration/components/table-cell/row-index-test.js
@@ -13,7 +13,7 @@ module('Integration | Component | table cell/row index', function(hooks) {
     let columns = [{ cellType: 'row-index' }];
     let rows = [{ text: 'Dummy' }, { text: 'Dummy' }, { text: 'Dummy' }];
 
-    this.set('table', new Table(columns, rows));
+    this.set('table', Table.create(columns, rows));
     await render(hbs`{{ui-tbody table=table}}`);
 
     assert.equal(findAll('tr').length, 3);

--- a/tests/integration/components/table-cell/row-number-test.js
+++ b/tests/integration/components/table-cell/row-number-test.js
@@ -13,7 +13,7 @@ module('Integration | Component | table cell/row number', function(hooks) {
     let columns = [{ cellType: 'row-number' }];
     let rows = [{ text: 'Dummy' }, { text: 'Dummy' }, { text: 'Dummy' }];
 
-    this.set('table', new Table(columns, rows));
+    this.set('table', Table.create(columns, rows));
     await render(hbs`{{ui-tbody table=table}}`);
 
     assert.equal(findAll('tr').length, 3);

--- a/tests/integration/components/ui-table-test.js
+++ b/tests/integration/components/ui-table-test.js
@@ -10,7 +10,7 @@ module('Integration | Component | ui table', function(hooks) {
   test('tag name is table', async function(assert) {
     assert.expect(1);
 
-    this.set('table', new Table());
+    this.set('table', Table.create());
     await render(hbs`{{ui-table table}}`);
 
     assert.ok(findAll('table').length);
@@ -19,7 +19,7 @@ module('Integration | Component | ui table', function(hooks) {
   test('single line table has class `single line`', async function(assert) {
     assert.expect(1);
 
-    this.set('table', new Table());
+    this.set('table', Table.create());
     await render(hbs`{{ui-table table singleLine=true}}`);
 
     assert.ok(find('table').className.indexOf('single line') !== -1);
@@ -28,7 +28,7 @@ module('Integration | Component | ui table', function(hooks) {
   test('sortable table has class `sortable`', async function(assert) {
     assert.expect(1);
 
-    this.set('table', new Table());
+    this.set('table', Table.create());
     await render(hbs`{{ui-table table sortable=true}}`);
 
     assert.ok(find('table').classList.contains('sortable'));
@@ -37,7 +37,7 @@ module('Integration | Component | ui table', function(hooks) {
   test('not stackable table has class `unstackable`', async function(assert) {
     assert.expect(1);
 
-    this.set('table', new Table());
+    this.set('table', Table.create());
     await render(hbs`{{ui-table table stacking=false}}`);
 
     assert.ok(find('table').classList.contains('unstackable'));
@@ -46,7 +46,7 @@ module('Integration | Component | ui table', function(hooks) {
   test('fixed table has class `fixed`', async function(assert) {
     assert.expect(1);
 
-    this.set('table', new Table());
+    this.set('table', Table.create());
     await render(hbs`{{ui-table table fixed=true}}`);
 
     assert.ok(find('table').classList.contains('fixed'));
@@ -55,7 +55,7 @@ module('Integration | Component | ui table', function(hooks) {
   test('striped table has class `striped`', async function(assert) {
     assert.expect(1);
 
-    this.set('table', new Table());
+    this.set('table', Table.create());
     await render(hbs`{{ui-table table striped=true}}`);
 
     assert.ok(find('table').classList.contains('striped'));
@@ -64,7 +64,7 @@ module('Integration | Component | ui table', function(hooks) {
   test('celled table has class `celled`', async function(assert) {
     assert.expect(1);
 
-    this.set('table', new Table());
+    this.set('table', Table.create());
     await render(hbs`{{ui-table table celled=true}}`);
 
     assert.ok(find('table').classList.contains('celled'));
@@ -73,7 +73,7 @@ module('Integration | Component | ui table', function(hooks) {
   test('padded table has class `padded`', async function(assert) {
     assert.expect(1);
 
-    this.set('table', new Table());
+    this.set('table', Table.create());
     await render(hbs`{{ui-table table padded=true}}`);
 
     assert.ok(find('table').classList.contains('padded'));
@@ -82,7 +82,7 @@ module('Integration | Component | ui table', function(hooks) {
   test('compact table has class `compact`', async function(assert) {
     assert.expect(1);
 
-    this.set('table', new Table());
+    this.set('table', Table.create());
     await render(hbs`{{ui-table table compact=true}}`);
 
     assert.ok(find('table').classList.contains('compact'));
@@ -91,7 +91,7 @@ module('Integration | Component | ui table', function(hooks) {
   test('small table has class `small`', async function(assert) {
     assert.expect(1);
 
-    this.set('table', new Table());
+    this.set('table', Table.create());
     await render(hbs`{{ui-table table size="small"}}`);
 
     assert.ok(find('table').classList.contains('small'));
@@ -100,7 +100,7 @@ module('Integration | Component | ui table', function(hooks) {
   test('large table has class `large`', async function(assert) {
     assert.expect(1);
 
-    this.set('table', new Table());
+    this.set('table', Table.create());
     await render(hbs`{{ui-table table size="large"}}`);
 
     assert.ok(find('table').classList.contains('large'));
@@ -109,7 +109,7 @@ module('Integration | Component | ui table', function(hooks) {
   test('table with row selection enabled has class `selectable`', async function(assert) {
     assert.expect(1);
 
-    this.set('table', new Table());
+    this.set('table', Table.create());
     await render(hbs`{{ui-table table rowSelection=true}}`);
 
     assert.ok(find('table').classList.contains('selectable'));

--- a/tests/integration/components/ui-tbody-test.js
+++ b/tests/integration/components/ui-tbody-test.js
@@ -21,7 +21,7 @@ module('Integration | Component | ui tbody', function(hooks) {
     let columns = [{ label: 'Column', valuePath: 'text' }];
     let rows = [{ text: 'This is a test' }];
 
-    this.set('table', new Table(columns, rows));
+    this.set('table', Table.create(columns, rows));
     await render(hbs`{{#ui-tbody table=table}}Table is empty{{/ui-tbody}}`);
 
     assert.equal(findAll('tr').length, 1);
@@ -32,7 +32,7 @@ module('Integration | Component | ui tbody', function(hooks) {
   test('it renders block content when table is empty', async function(assert) {
     assert.expect(1);
 
-    this.set('table', new Table());
+    this.set('table', Table.create());
     await render(hbs`{{#ui-tbody table=table}}Table is empty{{/ui-tbody}}`);
 
     assert.equal(this.element.textContent.trim(), 'Table is empty');
@@ -44,7 +44,7 @@ module('Integration | Component | ui tbody', function(hooks) {
     let columns = [{ label: 'Column', valuePath: 'text' }];
     let rows = [{ text: 'This is a test' }];
 
-    this.set('table', new Table(columns, rows));
+    this.set('table', Table.create(columns, rows));
     await render(hbs`{{#ui-tbody table=table expandedRowComponent="expanded-profile-row"}}{{/ui-tbody}}`);
 
     assert.equal(findAll('tr').length, 1);

--- a/tests/unit/classes/table-test.js
+++ b/tests/unit/classes/table-test.js
@@ -7,7 +7,7 @@ module('Unit | Classes | table', function() {
   test('Column instances are created when passed plain objects to table constructor', function(assert) {
     assert.expect(2);
 
-    let table = new Table([
+    let table = Table.create([
       {
         label: 'Column',
         valuePath: 'value'
@@ -22,7 +22,7 @@ module('Unit | Classes | table', function() {
   test('should not create a new Column object if a Column instance is provided', function(assert) {
     assert.expect(2);
 
-    let table = new Table([
+    let table = Table.create([
       Column.create({ label: 'Column' })
     ]);
 
@@ -34,7 +34,7 @@ module('Unit | Classes | table', function() {
   test('Row instances are created when passed plain objects to table constructor', function(assert) {
     assert.expect(2);
 
-    let table = new Table([], [
+    let table = Table.create([], [
       { foo: 'bar' }
     ]);
 
@@ -46,7 +46,7 @@ module('Unit | Classes | table', function() {
   test('should not create a new Row object if a Row instance is provided', function(assert) {
     assert.expect(2);
 
-    let table = new Table([], [
+    let table = Table.create([], [
       Row.create({ foo: 'bar' })
     ]);
 


### PR DESCRIPTION
Resolves deprecation [object.new-constructor](https://deprecations.emberjs.com/v3.x#toc_object-new-constructor).